### PR TITLE
Made use of the vanilla block breaking behavior

### DIFF
--- a/src/main/java/world/bentobox/oneblock/listeners/BlockListener.java
+++ b/src/main/java/world/bentobox/oneblock/listeners/BlockListener.java
@@ -210,17 +210,9 @@ public class BlockListener implements Listener {
             spawnEntity(nextBlock, block);
             return;
         }
-        // Break the block
-        if (e instanceof BlockBreakEvent) {
-            e.setCancelled(true);
-            block.breakNaturally();
-            // Give exp
-            player.giveExp(((BlockBreakEvent)e).getExpToDrop());
-            // Damage tool
-            damageTool(player);
-            spawnBlock(nextBlock, block);
-        } else if (e instanceof PlayerBucketFillEvent) {
-            Bukkit.getScheduler().runTask(addon.getPlugin(), ()-> spawnBlock(nextBlock, block));
+        // Replace the block by the following one
+        if (e instanceof BlockBreakEvent || e instanceof PlayerBucketFillEvent) {
+			Bukkit.getScheduler().runTask(addon.getPlugin(), () -> spawnBlock(nextBlock, block));
         }
         // Increment the block number
         is.incrementBlockNumber();
@@ -300,29 +292,6 @@ public class BlockListener implements Listener {
      */
     public OneBlockIslands getIsland(Island i) {
         return cache.containsKey(i.getUniqueId()) ? cache.get(i.getUniqueId()) : loadIsland(i.getUniqueId());
-    }
-
-    private void damageTool(@NonNull Player player) {
-        ItemStack inHand = player.getInventory().getItemInMainHand();
-        ItemMeta itemMeta = inHand.getItemMeta();
-        if (itemMeta instanceof Damageable && !itemMeta.isUnbreakable() && !inHand.getType().isBlock()
-                && inHand.getType().isItem()) {
-            Damageable meta = (Damageable) itemMeta;
-            Integer damage = meta.getDamage();
-            if (damage != null) {
-                // Check for DURABILITY
-                if (itemMeta.hasEnchant(Enchantment.DURABILITY)) {
-                    int level = itemMeta.getEnchantLevel(Enchantment.DURABILITY);
-                    if (random.nextInt(level + 1) == 0) {
-                        meta.setDamage(damage + 1);
-                    }
-                } else {
-                    meta.setDamage(damage + 1);
-                }
-                inHand.setItemMeta(itemMeta);
-            }
-        }
-
     }
 
     private OneBlockIslands loadIsland(String uniqueId) {


### PR DESCRIPTION
The current implementation to allow "breaking" blocks completely overrides the vanilla block breaking behavior. This really surprised me when I tried OneBlock: you're not supposed to get iron ores from breaking the block with your bare hands! You need tools! 🤣

Anyway, so this PR fixes that, as well as potentially all the other issues that could occur later on: e.g. changes to the Unbreaking enchantment, use of the Fortune enchantment, any plugins that allows players to break blocks in unexpected ways (explosive pickaxes, automated "block breakers"...).

This, however, calls for a rewrite of the first phase. You can't get cobble out of breaking stone with your bare hands, you need tools for that.

You could also add an option, or even a permission, to allow players to have "super hands". I personally do not want players to be able to break obsidian with their bare hands and get the obsidian item afterwards - but others might want that.